### PR TITLE
feat(protocol): implement `Ord` for `Severity`

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -162,14 +162,14 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for Box<dyn Diagnostic + Sen
 [`ReportHandler`](crate::ReportHandler)s to change the way different
 [`Diagnostic`]s are displayed.
 */
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum Severity {
-    /// Critical failure. The program cannot continue.
-    Error,
-    /// Warning. Please take note.
-    Warning,
     /// Just some help. Here's how you could be doing it better.
     Advice,
+    /// Warning. Please take note.
+    Warning,
+    /// Critical failure. The program cannot continue.
+    Error,
 }
 
 /**


### PR DESCRIPTION
I realize that I'm both (a) a newcomer to this community and (b) haven't proposed this idea anywhere. I figured a PR was the most straightforward way to communicate the idea. I'll also try to justify this proposal with some user thinking below, which I hope is convincing! 🙂

---

I have a use case where accumulate the “highest” severity observed during analysis of some artifacts for which I report diagnostics with `miette`. Slicing some code that I was working with (not up on GH yet) into a reduced example that I'd _like_ to work:

```rust
struct AnalysisStats {
    highest_severity_seen: Option<Severity>,
    // Maybe some other state…
}

impl AnalysisStats {
    fn track<T>(&mut self, t: T) -> T
    where
        T: Debug + Diagnostic + Display,
    {
        self.highest_severity_seen = Some(
            self.highest_severity_seen
                .unwrap_or(Severity::Error)
                .max(t.severity()),
        );
        t
    }
}
```

The simplest work-around for this issue I've found so far is to make a hidden `enum` that mirrors `Severity` and derive `Ord` on it, viz. something like this:

```rust
fn track<T>(&mut self, t: T) -> T
where
    T: Debug + Diagnostic + Display,
{
    #[derive(Eq, Ord, PartialEq, PartialOrd)]
    enum SeverityOrd {
        Error,
        Warning,
        Advice,
    }

    impl From<Severity> for SeverityOrd {
        fn from(value: Severity) -> Self {
            match value {
                Severity::Error => SeverityOrd::Error,
                Severity::Warning => SeverityOrd::Warning,
                Severity::Advice => SeverityOrd::Advice,
            }
        }
    }

    impl From<SeverityOrd> for Severity {
        fn from(value: SeverityOrd) -> Self {
            match value {
                SeverityOrd::Error => Severity::Error,
                SeverityOrd::Warning => Severity::Warning,
                SeverityOrd::Advice => Severity::Advice,
            }
        }
    }

    let severity = t.severity().unwrap_or(Severity::Error);
    self.highest_severity_seen =
        Some(self.highest_severity_seen.clone().map_or(severity, |s| {
            SeverityOrd::from(s).max(severity.into()).into()
        }));
    t
}
```

The above is an unfortunate amount of code. 😅 I believe `Severity` should implement `Ord`, because:

1. The notion of the “height” of severity is fairly clear (e.g., higher is worse).
2. Accumulating severity like this is not uncommon in applications that I've worked with.

I'm not sure why this isn't part of the API currently; I couldn't find anything after hunting through issues, PRs, and commits. Perhaps this is just an oversight?